### PR TITLE
change php-fpm upstream name to more universal: "php-upstream"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD application.conf /etc/nginx/sites-available/
 RUN ln -s /etc/nginx/sites-available/application.conf /etc/nginx/sites-enabled/application
 RUN rm /etc/nginx/sites-enabled/default
 
-RUN echo "upstream php-upstream { server php-fpm:9000; }" > /etc/nginx/conf.d/upstream.conf
+RUN echo "upstream php-upstream { server php-upstream:9000; }" > /etc/nginx/conf.d/upstream.conf
 
 RUN usermod -u 1000 www-data
 


### PR DESCRIPTION
Initially default nginx upstream for php was "php-fpm".
It forced to use "php-fpm" as a name for php service in docker-compose.yml 
If we consider switching between hhvm & php-fpm maybe we should more generic name like "php-upstream".
